### PR TITLE
Feature/testing failures

### DIFF
--- a/MetovaTestKit.xcodeproj/project.pbxproj
+++ b/MetovaTestKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4A771F311D4C144400EFD0B8 /* MTKBrokenConstraintCounter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A771F2F1D4C144400EFD0B8 /* MTKBrokenConstraintCounter.m */; };
 		4A771F331D4C155700EFD0B8 /* MTKConstraintTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A771F321D4C155700EFD0B8 /* MTKConstraintTester.swift */; };
 		4A771F351D4C173300EFD0B8 /* ConstraintTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A771F341D4C173300EFD0B8 /* ConstraintTestingTests.swift */; };
+		4A771FC91D4D534200EFD0B8 /* MTKBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A771FC81D4D534200EFD0B8 /* MTKBaseTestCase.swift */; };
 		4A8AD4E91CDEA2A30085984D /* MTKTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AD4E81CDEA2A30085984D /* MTKTestable.swift */; };
 		4A8AD4EB1CDEA2B60085984D /* MTKExceptionTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AD4EA1CDEA2B60085984D /* MTKExceptionTesting.swift */; };
 		4A8AD4ED1CDEA53A0085984D /* MTKTestable+UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AD4EC1CDEA53A0085984D /* MTKTestable+UIViewController.swift */; };
@@ -57,6 +58,7 @@
 		4A771F2F1D4C144400EFD0B8 /* MTKBrokenConstraintCounter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTKBrokenConstraintCounter.m; path = ConstraintTesting/MTKBrokenConstraintCounter.m; sourceTree = "<group>"; };
 		4A771F321D4C155700EFD0B8 /* MTKConstraintTester.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MTKConstraintTester.swift; path = ConstraintTesting/MTKConstraintTester.swift; sourceTree = "<group>"; };
 		4A771F341D4C173300EFD0B8 /* ConstraintTestingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintTestingTests.swift; sourceTree = "<group>"; };
+		4A771FC81D4D534200EFD0B8 /* MTKBaseTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTKBaseTestCase.swift; sourceTree = "<group>"; };
 		4A8AD4E81CDEA2A30085984D /* MTKTestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MTKTestable.swift; path = ViewControllerTesting/MTKTestable.swift; sourceTree = "<group>"; };
 		4A8AD4EA1CDEA2B60085984D /* MTKExceptionTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MTKExceptionTesting.swift; path = ExceptionTesting/MTKExceptionTesting.swift; sourceTree = "<group>"; };
 		4A8AD4EC1CDEA53A0085984D /* MTKTestable+UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MTKTestable+UIViewController.swift"; path = "ViewControllerTesting/MTKTestable+UIViewController.swift"; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 			children = (
 				4A8AD4EE1CDEB6300085984D /* Supporting Test Files */,
 				4A3CFF081CDD5F37003EF6F0 /* Info.plist */,
+				4A771FC81D4D534200EFD0B8 /* MTKBaseTestCase.swift */,
 				4A3CFFCD1CDE1548003EF6F0 /* ExceptionTestingTests.swift */,
 				4A8AD4F31CDEB7A60085984D /* TestableProtocolTests.swift */,
 				4A771F341D4C173300EFD0B8 /* ConstraintTestingTests.swift */,
@@ -356,6 +359,7 @@
 			files = (
 				4A8AD4F11CDEB6C30085984D /* TestableViewController.swift in Sources */,
 				4A771F351D4C173300EFD0B8 /* ConstraintTestingTests.swift in Sources */,
+				4A771FC91D4D534200EFD0B8 /* MTKBaseTestCase.swift in Sources */,
 				4A8AD4F41CDEB7A60085984D /* TestableProtocolTests.swift in Sources */,
 				4A3CFFCE1CDE1548003EF6F0 /* ExceptionTestingTests.swift in Sources */,
 			);

--- a/MetovaTestKitTests/ConstraintTestingTests.swift
+++ b/MetovaTestKitTests/ConstraintTestingTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import MetovaTestKit
 
-class ConstraintTestingTests: XCTestCase {
+class ConstraintTestingTests: MTKBaseTestCase {
 
     func testBrokenConstraintCount() {
         let count = MTKAssertNoBrokenConstraints {

--- a/MetovaTestKitTests/ConstraintTestingTests.swift
+++ b/MetovaTestKitTests/ConstraintTestingTests.swift
@@ -10,19 +10,92 @@ import XCTest
 
 @testable import MetovaTestKit
 
+extension NSLayoutConstraint {
+    
+    convenience init(view: UIView, width: CGFloat) {
+        self.init(item: view,
+            attribute: .Width,
+            relatedBy: .Equal,
+            toItem: nil,
+            attribute: .NotAnAttribute,
+            multiplier: 1.0,
+            constant: width
+        )
+    }
+    
+}
+
 class ConstraintTestingTests: MTKBaseTestCase {
 
     func testBrokenConstraintCount() {
         let count = MTKAssertNoBrokenConstraints {
-            // doing nothing should break no constraints
-            // TODO: Do some real UIView work that doesn't break constraints.
+            let window = UIWindow()
+            let view = UIView()
+            
+            window.addSubview(view)
+            
+            view.translatesAutoresizingMaskIntoConstraints = false
+            
+            view.addConstraint(NSLayoutConstraint(view: view, width: 200))
+            
+            view.updateConstraints()
         }
         
         XCTAssertEqual(0, count)
     }
     
     func testAssertNoBrokenConstraintsFails() {
-        // TODO: Find a way to verify that a broken constraint will cause MTKAssertNoBrokenConstraints to fail and cause THIS test to pass.
+        
+        let message = "Broken constraints!"
+        let description = "XCTAssertEqual failed: (\"Optional(0)\") is not equal to (\"Optional(2)\") - \(message)"
+        
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 54)) {
+            
+            let count = MTKAssertNoBrokenConstraints(message: message) {
+                let window = UIWindow()
+                let view = UIView()
+                
+                window.addSubview(view)
+                
+                view.translatesAutoresizingMaskIntoConstraints = false
+                
+                view.addConstraint(NSLayoutConstraint(view: view, width: 50))
+                view.addConstraint(NSLayoutConstraint(view: view, width: 100))
+                view.addConstraint(NSLayoutConstraint(view: view, width: 200))
+                
+                view.updateConstraints()
+            }
+            
+            XCTAssertEqual(2, count)
+        }
+        
+    }
+    
+    func testAssertNoBrokenConstraintsDefaultMessageFails() {
+        
+        let defaultMessage = "Found 2 broken constraints while executing test block."
+        let description = "XCTAssertEqual failed: (\"Optional(0)\") is not equal to (\"Optional(2)\") - \(defaultMessage)"
+        
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 81)) {
+            
+            let count = MTKAssertNoBrokenConstraints {
+                let window = UIWindow()
+                let view = UIView()
+                
+                window.addSubview(view)
+                
+                view.translatesAutoresizingMaskIntoConstraints = false
+                
+                view.addConstraint(NSLayoutConstraint(view: view, width: 50))
+                view.addConstraint(NSLayoutConstraint(view: view, width: 100))
+                view.addConstraint(NSLayoutConstraint(view: view, width: 200))
+                
+                view.updateConstraints()
+            }
+            
+            XCTAssertEqual(2, count)
+        }
+        
     }
 
 }

--- a/MetovaTestKitTests/ExceptionTestingTests.swift
+++ b/MetovaTestKitTests/ExceptionTestingTests.swift
@@ -55,11 +55,59 @@ class ExceptionTestingTests: MTKBaseTestCase {
     }
     
     func testAssertNoExceptionFails() {
-        // TODO: Find a way to verify that MTKAssertNoException fails.  I know it fails, but the only way I can get it to fail also fails *this* test itself.  How do we verify a test fails without failing the test that's testing it?
+        
+        let message = "Test Failed!"
+        let description = "XCTAssertNil failed: \"*** -[__NSArray0 objectAtIndex:]: index 3 beyond bounds for empty NSArray\" - \(message)"
+        
+        var didReachEnd: Bool?
+        
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 66)) {
+            
+            MTKAssertNoException(message: message) {
+                didReachEnd = false
+                
+                let arr: NSArray = []
+                arr.objectAtIndex(3)
+                
+                didReachEnd = true
+            }
+        }
+        
+        guard let endReached = didReachEnd else {
+            XCTFail("Test block was not executed.")
+            return
+        }
+        
+        XCTAssertFalse(endReached)
+        
     }
     
     func testAssertNoExceptionDefaultMessageFails() {
-        // TODO: Same as above method, but use default for message argument.
+        
+        let defaultMessage = "Caught exception while executing test block."
+        let description = "XCTAssertNil failed: \"*** -[__NSArray0 objectAtIndex:]: index 3 beyond bounds for empty NSArray\" - \(defaultMessage)"
+        
+        var didReachEnd: Bool?
+        
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 94)) {
+            
+            MTKAssertNoException {
+                didReachEnd = false
+                
+                let arr: NSArray = []
+                arr.objectAtIndex(3)
+                
+                didReachEnd = true
+            }
+        }
+        
+        guard let endReached = didReachEnd else {
+            XCTFail("Test block was not executed.")
+            return
+        }
+        
+        XCTAssertFalse(endReached)
+        
     }
     
     func testAssertNoExceptionReturnsNilWhenPassing() {
@@ -115,11 +163,65 @@ class ExceptionTestingTests: MTKBaseTestCase {
     }
     
     func testAssertExceptionFails() {
-        // TODO: Find a way to verify that MTKAssertException fails.  I know it fails, but the only way I can get it to fail also fails *this* test itself.  How do we verify a test fails without failing the test that's testing it?
+        
+        let message = "Test failed!"
+        let description = "XCTAssertNotNil failed - \(message)"
+        
+        var didReachEnd: Bool?
+
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 174)) {
+            
+            MTKAssertException(message: message) {
+                
+                didReachEnd = false
+                
+                let arr: NSArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                arr.objectAtIndex(3)
+                
+                didReachEnd = true
+                
+            }
+            
+        }
+        
+        guard let endReached = didReachEnd else {
+            XCTFail("Test block was not executed.")
+            return
+        }
+        
+        XCTAssertTrue(endReached)
+        
     }
     
     func testAssertExceptionDefaultMessageFails() {
-        // TODO: Same as above method, but use default for message argument.
+        
+        let defaultMessage = "Did not catch exception while executing test block."
+        let description = "XCTAssertNotNil failed - \(defaultMessage)"
+        
+        var didReachEnd: Bool?
+        
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: 205)) {
+            
+            MTKAssertException {
+                
+                didReachEnd = false
+                
+                let arr: NSArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                arr.objectAtIndex(3)
+                
+                didReachEnd = true
+                
+            }
+            
+        }
+        
+        guard let endReached = didReachEnd else {
+            XCTFail("Test block was not executed.")
+            return
+        }
+        
+        XCTAssertTrue(endReached)
+        
     }
     
     func testAssertExceptionCatchesCorrectException() {

--- a/MetovaTestKitTests/ExceptionTestingTests.swift
+++ b/MetovaTestKitTests/ExceptionTestingTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import MetovaTestKit
 
-class ExceptionTestingTests: XCTestCase {
+class ExceptionTestingTests: MTKBaseTestCase {
 
     func testAssertNoExceptionPasses() {
         

--- a/MetovaTestKitTests/MTKBaseTestCase.swift
+++ b/MetovaTestKitTests/MTKBaseTestCase.swift
@@ -1,0 +1,62 @@
+//
+//  BaseTestCase.swift
+//  MetovaTestKit
+//
+//  Created by Nick Griffith on 7/30/16.
+//  Copyright © 2016 Metova. All rights reserved.
+//
+
+/*
+ 
+ This base test class allows us to verify that the various assertions we're creating through MTK actually throw failures.  The current implementation just allows one failed test per `expectTestFailure` block.  We can potentially modify this in the future, but I think for now, the expectation should be that tests are written expecting just one failure.  Any assertion failures after the first will fail as normal.
+ 
+ The idea for this implementation came from an answer received on this Stack Overflow question: http://stackoverflow.com/q/38675192/2792531
+ 
+ */
+
+import XCTest
+
+struct TestFailureExpectation {
+    
+    let description: String?
+    let filePath: String?
+    let lineNumber: UInt?
+    
+    init(description: String? = nil, filePath: String? = nil, lineNumber: UInt? = nil) {
+        self.description = description
+        self.filePath = filePath
+        self.lineNumber = lineNumber
+    }
+    
+}
+
+class MTKBaseTestCase: XCTestCase {
+
+    private var expectingFailure: TestFailureExpectation?
+    
+    override func recordFailureWithDescription(description: String, inFile filePath: String, atLine lineNumber: UInt, expected: Bool) {
+        if let expectedFailure = expectingFailure where expected
+            && (expectedFailure.description == nil || expectedFailure.description == description)
+            && (expectedFailure.filePath == nil || expectedFailure.filePath == filePath)
+            && (expectedFailure.lineNumber == nil || expectedFailure.lineNumber == lineNumber) {
+            
+            expectingFailure = nil
+        }
+        else {
+            super.recordFailureWithDescription(description, inFile: filePath, atLine: lineNumber, expected: expected)
+        }
+    }
+    
+    func expectTestFailure(failure: TestFailureExpectation = TestFailureExpectation(), @autoclosure message: () -> String? = nil, file: StaticString = #file, line: UInt = #line, @noescape inBlock testBlock: () -> Void) {
+        expectingFailure = failure
+        testBlock()
+        
+        if expectingFailure != nil {
+            expectingFailure = nil
+            let message = message() ?? "Failed to catch test failure in block."
+            XCTFail(message, file: file, line: line)
+        }
+        
+    }
+    
+}

--- a/MetovaTestKitTests/MTKBaseTestCase.swift
+++ b/MetovaTestKitTests/MTKBaseTestCase.swift
@@ -18,11 +18,13 @@ import XCTest
 
 struct TestFailureExpectation {
     
+    let message: String?
     let description: String?
     let filePath: String?
     let lineNumber: UInt?
     
-    init(description: String? = nil, filePath: String? = nil, lineNumber: UInt? = nil) {
+    init(message: String? = nil, description: String? = nil, filePath: String? = nil, lineNumber: UInt? = nil) {
+        self.message = message
         self.description = description
         self.filePath = filePath
         self.lineNumber = lineNumber
@@ -35,8 +37,10 @@ class MTKBaseTestCase: XCTestCase {
     private var expectingFailure: TestFailureExpectation?
     
     override func recordFailureWithDescription(description: String, inFile filePath: String, atLine lineNumber: UInt, expected: Bool) {
+        
         if let expectedFailure = expectingFailure where expected
-            && (expectedFailure.description == nil || expectedFailure.description == description)
+            && (expectedFailure.message == nil || description.hasSuffix(expectedFailure.message ?? ""))
+            && (expectedFailure.description == nil || description == expectedFailure.description)
             && (expectedFailure.filePath == nil || expectedFailure.filePath == filePath)
             && (expectedFailure.lineNumber == nil || expectedFailure.lineNumber == lineNumber) {
             

--- a/MetovaTestKitTests/TestableProtocolTests.swift
+++ b/MetovaTestKitTests/TestableProtocolTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class TestableProtocolTests: XCTestCase {
+class TestableProtocolTests: MTKBaseTestCase {
     
     func testDidCallLoadView() {
         let expectation = expectationWithDescription("Block executed")


### PR DESCRIPTION
We can now write unit tests to verify that our custom assertion functions actually fail tests.

This PR resolves https://github.com/metova/MetovaTestKit/issues/2
