### PR TITLE
Modernize spacing after a period.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,7 @@ disabled_rules: # rule identifiers to exclude from running
   - trailing_whitespace
   - statement_position
   - opening_brace
-  - file_length # This rule counts white space and comments.  Re-enabled when we've fixed it to not do that.
+  - file_length # This rule counts white space and comments. Re-enabled when we've fixed it to not do that.
   - nesting
 opt_in_rules: # some rules are only opt-in
   - missing_docs # There's currently a bug with the missing_docs rule resulting in false warnings. https://github.com/realm/SwiftLint/issues/811

--- a/MetovaTestKit/ConstraintTesting/MTKConstraintTester.swift
+++ b/MetovaTestKit/ConstraintTesting/MTKConstraintTester.swift
@@ -30,7 +30,7 @@
 import XCTest
 
 /**
-  Synchronously tests the provided block for broken constraints.  If any constraints are broken, the test fails.  Otherwise, it passes.
+  Synchronously tests the provided block for broken constraints. If any constraints are broken, the test fails. Otherwise, it passes.
  
  - parameter message:   The message to log upon test failure.
  - parameter file:      The file the test is called from.

--- a/MetovaTestKit/ExceptionTesting/MTKExceptionTester.h
+++ b/MetovaTestKit/ExceptionTesting/MTKExceptionTester.h
@@ -32,15 +32,15 @@
 #import <Foundation/Foundation.h>
 
 /**
- Synchronously tests the provided block for exceptions.  If it would throw an exception, it catches the exception and returns it.
+ Synchronously tests the provided block for exceptions. If it would throw an exception, it catches the exception and returns it.
  
  @param testBlock The block to test.
 
- @return The caught exception.  If no exception was thrown, returns `nil`.
+ @return The caught exception. If no exception was thrown, returns `nil`.
  
- @warning You should not rely on `XCTestExpectation` fulfillment in this block.  If an exception is thrown before fulfillment, the expectation will never be fulfilled.  `XCTestExpectation` should be unnecessary as the block is executed synchronously.
+ @warning You should not rely on `XCTestExpectation` fulfillment in this block. If an exception is thrown before fulfillment, the expectation will never be fulfilled. `XCTestExpectation` should be unnecessary as the block is executed synchronously.
  
- @warning This will only catch Objective-C-style exceptions.  Swift's `fatalError`'s are not caught by this test.
+ @warning This will only catch Objective-C-style exceptions. Swift's `fatalError`'s are not caught by this test.
  
  */
 NSException * __nullable MTKCatchException(__attribute__((noescape)) void (^ __nonnull testBlock)());

--- a/MetovaTestKit/ExceptionTesting/MTKExceptionTesting.swift
+++ b/MetovaTestKit/ExceptionTesting/MTKExceptionTesting.swift
@@ -30,18 +30,18 @@
 import XCTest
 
 /**
- Synchronously tests the provided block for exceptions.  If it would throw an exception, the exception is caught and the test fails.  Otherwise, the test passes.
+ Synchronously tests the provided block for exceptions. If it would throw an exception, the exception is caught and the test fails. Otherwise, the test passes.
  
  - parameter message:   The message to log upon test failure.
  - parameter file:      The file the test is called from.
  - parameter line:      The line number the test is called from.
  - parameter testBlock: The block to test.
  
- - returns: The caught exception.  If no exception was thrown, returns `nil`.
+ - returns: The caught exception. If no exception was thrown, returns `nil`.
  
- - warning: You should not rely on `XCTestExpectation` fulfillment in this block.  If an exception is thrown before fulfillment, the expectation will never be fulfilled.  `XCTestExpectation` should be unnecessary as the block is executed synchronously.
+ - warning: You should not rely on `XCTestExpectation` fulfillment in this block. If an exception is thrown before fulfillment, the expectation will never be fulfilled. `XCTestExpectation` should be unnecessary as the block is executed synchronously.
  
- - warning: This will only catch Objective-C-style exceptions.  Swift's `fatalError`s are not caught by this test.
+ - warning: This will only catch Objective-C-style exceptions. Swift's `fatalError`s are not caught by this test.
  */
 @discardableResult public func MTKAssertNoException(message: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line, testBlock: () -> Void) -> NSException? {
   
@@ -54,18 +54,18 @@ import XCTest
 }
 
 /**
- Synchronously tests the provided block for exceptions.  If it does not throw an exception, the test fails.  If it would throw an exception, the exception is caught and the test passes.  Any code below the thrown exception is not executed.
+ Synchronously tests the provided block for exceptions. If it does not throw an exception, the test fails. If it would throw an exception, the exception is caught and the test passes. Any code below the thrown exception is not executed.
  
  - parameter message:   The message to log upon test failure.
  - parameter file:      The file the test is called from.
  - parameter line:      The line number the test is called from.
  - parameter testBlock: The block to test.
  
- - returns: The caught exception.  If no exception was thrown, returns `nil`.
+ - returns: The caught exception. If no exception was thrown, returns `nil`.
  
- - warning: You should not rely on `XCTestExpectation` fulfillment in this block.  If an exception is thrown before fulfillment, the expectation will never be fulfilled.  `XCTestExpectation` should be unnecessary as the block is executed synchronously.
+ - warning: You should not rely on `XCTestExpectation` fulfillment in this block. If an exception is thrown before fulfillment, the expectation will never be fulfilled. `XCTestExpectation` should be unnecessary as the block is executed synchronously.
  
- - warning: This will only catch Objective-C-style exceptions.  Swift's `fatalError`s are not caught by this test.
+ - warning: This will only catch Objective-C-style exceptions. Swift's `fatalError`s are not caught by this test.
  */
 @discardableResult public func MTKAssertException(message: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line, testBlock: () -> Void) -> NSException? {
     

--- a/MetovaTestKit/ViewControllerTesting/MTKTestable.swift
+++ b/MetovaTestKit/ViewControllerTesting/MTKTestable.swift
@@ -59,10 +59,10 @@
  
      }
  
- This allows `setUp` & `tearDown` code to exist across multiple files.  Moreover, `setUp` & `tearDown` logic could now be inherited.  As well, `MTKTestable` protocol extensions could be written to generalize some of the `setUp` & `tearDown` logic for large collections of types.
+ This allows `setUp` & `tearDown` code to exist across multiple files. Moreover, `setUp` & `tearDown` logic could now be inherited. As well, `MTKTestable` protocol extensions could be written to generalize some of the `setUp` & `tearDown` logic for large collections of types.
  
  - Note 
- `UIViewController` and its subclasses get a free implementation of `test(_:)` as long as they have implemented `instanceForTesting()`.  The default `test(_:)` implementation for view controllers calls `loadView()` and `viewDidLoad()` before running the `testBlock`.
+ `UIViewController` and its subclasses get a free implementation of `test(_:)` as long as they have implemented `instanceForTesting()`. The default `test(_:)` implementation for view controllers calls `loadView()` and `viewDidLoad()` before running the `testBlock`.
  
  */
 public protocol MTKTestable {
@@ -77,7 +77,7 @@ public protocol MTKTestable {
     static func test(_ testBlock: (TestableItem) -> Void)
     
     /**
-     Asks the `MTKTestable` type for a new instance in order to be used for testing.  This method should provide a new instance every time.
+     Asks the `MTKTestable` type for a new instance in order to be used for testing. This method should provide a new instance every time.
      
      - returns: A new instance, ready for testing.
      */

--- a/MetovaTestKitTests/MTKBaseTestCase.swift
+++ b/MetovaTestKitTests/MTKBaseTestCase.swift
@@ -29,7 +29,7 @@
 
 /*
  
- This base test class allows us to verify that the various assertions we're creating through MTK actually throw failures.  The current implementation just allows one failed test per `expectTestFailure` block.  We can potentially modify this in the future, but I think for now, the expectation should be that tests are written expecting just one failure.  Any assertion failures after the first will fail as normal.
+ This base test class allows us to verify that the various assertions we're creating through MTK actually throw failures. The current implementation just allows one failed test per `expectTestFailure` block. We can potentially modify this in the future, but I think for now, the expectation should be that tests are written expecting just one failure. Any assertion failures after the first will fail as normal.
  
  The idea for this implementation came from an answer received on this Stack Overflow question: http://stackoverflow.com/q/38675192/2792531
  

--- a/MetovaTestKitTests/SupportingTestFiles/TestableViewController.swift
+++ b/MetovaTestKitTests/SupportingTestFiles/TestableViewController.swift
@@ -30,7 +30,7 @@
 import UIKit
 @testable import MetovaTestKit
 
-// This class exists for the purposes of testing the MTKTestable protocol.  In a real project, the class definition would exist in the main target.  The MTKTestable extension would exist in a separate file and only part of the test target.
+// This class exists for the purposes of testing the MTKTestable protocol. In a real project, the class definition would exist in the main target. The MTKTestable extension would exist in a separate file and only part of the test target.
 
 class TestableViewController: UIViewController {
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pod 'MTK', :git => 'https://github.com/metova/MetovaTestKit.git', :branch => 'de
 
 ### MTKTestable
 
-Metova Test Kit defines the `MTKTestable` protocol.  Correct implementation of this protocol allows for functional unit testing.  It abstracts away the set up and tear down code into extensions of the types you want to test, and allows for functional unit tests.
+Metova Test Kit defines the `MTKTestable` protocol. Correct implementation of this protocol allows for functional unit testing. It abstracts away the set up and tear down code into extensions of the types you want to test, and allows for functional unit tests.
 
 ```swift
 func testOutlets() {
@@ -86,7 +86,7 @@ MTKAssertNoBrokenConstraints {
 }
 ```
 
-This assertion will fail for any broken constraints and report the number of constraints that broke during the test.  You can also pass a custom message.
+This assertion will fail for any broken constraints and report the number of constraints that broke during the test. You can also pass a custom message.
 
 ```swift
 MTKAssertNoBrokenConstraints(message: "Constraints were broken.") {
@@ -104,7 +104,7 @@ let brokenConstraintCount = MTKAssertNoBrokenConstraints {
 
 ### Testing Exceptions
 
-You can use Metova Test Kit to assert that code that should not throw exceptions doesn't.  Without MTK, this would result in the entire test suite crashing.  With MTK, this is just a failed test, and you still get to run the rest of the test suite.
+You can use Metova Test Kit to assert that code that should not throw exceptions doesn't. Without MTK, this would result in the entire test suite crashing. With MTK, this is just a failed test, and you still get to run the rest of the test suite.
 
 ```swift
 MTKAssertNoException {
@@ -124,7 +124,7 @@ MTKAssertNoException(message: "Exception was thrown.") {
 }
 ```
 
-You can also test code to verify that exceptions are thrown, and can do this without crashing your test suite.  If you do not care about the specific exception but only want to verify that the code block throws an exception, you can use `MTKAssertException`:
+You can also test code to verify that exceptions are thrown, and can do this without crashing your test suite. If you do not care about the specific exception but only want to verify that the code block throws an exception, you can use `MTKAssertException`:
 
 ```swift
 MTKAssertException {
@@ -162,7 +162,7 @@ if let exception = MTKAssertNoException(testBlock: blockThatShouldntThrow) {
 }
 ```
 
-If the closure did not throw an exception, the function returns `nil`.  Otherwise, it returns an instance of `NSException` which you can verify is the exception you expected your block to throw.
+If the closure did not throw an exception, the function returns `nil`. Otherwise, it returns an instance of `NSException` which you can verify is the exception you expected your block to throw.
 
 -----
 


### PR DESCRIPTION
@nhgrif I had to do this because it was driving me nuts. 

https://www.cultofpedagogy.com/two-spaces-after-period/
http://www.quickanddirtytips.com/education/grammar/two-spaces-after-a-period
http://www.slate.com/articles/technology/technology/2011/01/space_invaders.html

😬 