### PR TITLE
Add bar button item target/action assertion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added assertion for UISegmentedControl segment titles.
 - Added async testing utility.
 - Added assertion for displaying UIAlertControllers.
+- Added assertion for UIBarButtonItem target/action.
 
 ## 1.0.0
 

--- a/MetovaTestKit.xcodeproj/project.pbxproj
+++ b/MetovaTestKit.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		4A8AD4F11CDEB6C30085984D /* TestableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AD4EF1CDEB6C30085984D /* TestableViewController.swift */; };
 		4A8AD4F21CDEB6C30085984D /* TestableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A8AD4F01CDEB6C30085984D /* TestableViewController.xib */; };
 		4A8AD4F41CDEB7A60085984D /* TestableProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AD4F31CDEB7A60085984D /* TestableProtocolTests.swift */; };
+		6E0D0B441F1FEC7A00600571 /* UIBarButtonItemAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0D0B431F1FEC7A00600571 /* UIBarButtonItemAssertions.swift */; };
+		6E0D0B461F1FEE3900600571 /* UIBarButtonItemTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0D0B451F1FEE3900600571 /* UIBarButtonItemTestingTests.swift */; };
 		6E2368361F046B26008E3231 /* QuotedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2368351F046B26008E3231 /* QuotedString.swift */; };
 		6E2616EC1F18060200D9B507 /* UIAlertControllerTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2616EB1F18060200D9B507 /* UIAlertControllerTestingTests.swift */; };
 		6E8D4B081EB7C5DF001284FD /* FailureRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8D4B071EB7C5DF001284FD /* FailureRecording.swift */; };
@@ -81,6 +83,8 @@
 		4A8AD4F51CDEDF110085984D /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		4A8AD4F71CDEE4220085984D /* .travis.yml */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		4AB9A3E01CDF6AB00021B6B8 /* Gemfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; indentWidth = 2; path = Gemfile; sourceTree = "<group>"; };
+		6E0D0B431F1FEC7A00600571 /* UIBarButtonItemAssertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemAssertions.swift; sourceTree = "<group>"; };
+		6E0D0B451F1FEE3900600571 /* UIBarButtonItemTestingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemTestingTests.swift; sourceTree = "<group>"; };
 		6E2368351F046B26008E3231 /* QuotedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QuotedString.swift; path = "Internal Utilities/QuotedString.swift"; sourceTree = "<group>"; };
 		6E2616EB1F18060200D9B507 /* UIAlertControllerTestingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertControllerTestingTests.swift; path = "UIKit Testing Tests/UIAlertControllerTestingTests.swift"; sourceTree = "<group>"; };
 		6E8D4B071EB7C5DF001284FD /* FailureRecording.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FailureRecording.swift; path = "Internal Utilities/FailureRecording.swift"; sourceTree = "<group>"; };
@@ -235,9 +239,10 @@
 		6E8D4AFF1EB7AB70001284FD /* UIKitTesting */ = {
 			isa = PBXGroup;
 			children = (
+				6ED689001EFC2D3C0040C243 /* UIAlertControllerAssertions.swift */,
+				6E0D0B431F1FEC7A00600571 /* UIBarButtonItemAssertions.swift */,
 				6E8D4B181EB8138B001284FD /* UIControlAssertions.swift */,
 				6E8D4B211EB941B9001284FD /* UISegmentedControlAssertions.swift */,
-				6ED689001EFC2D3C0040C243 /* UIAlertControllerAssertions.swift */,
 			);
 			name = UIKitTesting;
 			sourceTree = "<group>";
@@ -255,9 +260,10 @@
 		6E8D4B171EB81064001284FD /* UIKit Testing Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6E2616EB1F18060200D9B507 /* UIAlertControllerTestingTests.swift */,
+				6E0D0B451F1FEE3900600571 /* UIBarButtonItemTestingTests.swift */,
 				6E8D4B0B1EB7CF67001284FD /* UIControlTestingTests.swift */,
 				6EF9B23A1EBBA65600B87FA3 /* UISegmentedControlTestingTests.swift */,
-				6E2616EB1F18060200D9B507 /* UIAlertControllerTestingTests.swift */,
 			);
 			name = "UIKit Testing Tests";
 			sourceTree = "<group>";
@@ -445,6 +451,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E8D4B241EB941F8001284FD /* Array+Utilities.swift in Sources */,
+				6E0D0B441F1FEC7A00600571 /* UIBarButtonItemAssertions.swift in Sources */,
 				6E2368361F046B26008E3231 /* QuotedString.swift in Sources */,
 				4A771F331D4C155700EFD0B8 /* MTKConstraintTester.swift in Sources */,
 				4A771F311D4C144400EFD0B8 /* MTKBrokenConstraintCounter.m in Sources */,
@@ -471,6 +478,7 @@
 				6EF9B23B1EBBA65600B87FA3 /* UISegmentedControlTestingTests.swift in Sources */,
 				4A8AD4F41CDEB7A60085984D /* TestableProtocolTests.swift in Sources */,
 				6E2616EC1F18060200D9B507 /* UIAlertControllerTestingTests.swift in Sources */,
+				6E0D0B461F1FEE3900600571 /* UIBarButtonItemTestingTests.swift in Sources */,
 				6EC1A6B31EBCE2E2000DEFA6 /* AsyncTestingTests.swift in Sources */,
 				4A3CFFCE1CDE1548003EF6F0 /* ExceptionTestingTests.swift in Sources */,
 				6E8D4B0C1EB7CF68001284FD /* UIControlTestingTests.swift in Sources */,

--- a/MetovaTestKit/UIBarButtonItemAssertions.swift
+++ b/MetovaTestKit/UIBarButtonItemAssertions.swift
@@ -1,0 +1,67 @@
+//
+//  UIBarButtonItemAssertions.swift
+//  MetovaTestKit
+//
+//  Created by Logan Gauthier on 7/19/17.
+//  Copyright © 2017 Metova. All rights reserved.
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  "Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import XCTest
+
+/// Passes if the bar button item has the specified target/action and the target responds to the action. Fails otherwise.
+///
+/// - Parameters:
+///   - barButtonItem: The bar button item to test.
+///   - action: The message that should be sent to `target`.
+///   - target: The object that the `action` should be sent to.
+///   - failureMessage: The message to log upon failure.
+///   - file: The name of the file to report the failure for. The default value will report the file from which this method is called.
+///   - line: The line number to report the failure for. The default value will report the line number of the calling site.
+public func MTKAssertBarButtonItem(_ barButtonItem: UIBarButtonItem, sends action: Selector, to target: NSObject, _ failureMessage: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line) {
+    
+    guard let actualAction = barButtonItem.action else {
+        MTKRecordFailure(withMessage: failureMessage(), description: "The bar button item's action is nil.", file: file, line: line)
+        return
+    }
+    
+    guard actualAction == action else {
+        MTKRecordFailure(withMessage: failureMessage(), description: "Expected the bar button item to have action `\(action)`. Instead found `\(actualAction)`.", file: file, line: line)
+        return
+    }
+    
+    guard let actualTarget = barButtonItem.target else {
+        MTKRecordFailure(withMessage: failureMessage(), description: "The bar button item's target is nil.", file: file, line: line)
+        return
+    }
+    
+    guard actualTarget === target else {
+        MTKRecordFailure(withMessage: failureMessage(), description: "Expected the bar button item to have target `\(target)`. Instead found `\(actualTarget)`.", file: file, line: line)
+        return
+    }
+    
+    guard actualTarget.responds(to: actualAction) else {
+        MTKRecordFailure(withMessage: failureMessage(), description: "The target does not respond to the action.", file: file, line: line)
+        return
+    }
+}

--- a/MetovaTestKitTests/UIBarButtonItemTestingTests.swift
+++ b/MetovaTestKitTests/UIBarButtonItemTestingTests.swift
@@ -1,0 +1,115 @@
+//
+//  UIBarButtonItemTestingTests.swift
+//  MetovaTestKit
+//
+//  Created by Logan Gauthier on 7/19/17.
+//  Copyright © 2017 Metova. All rights reserved.
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  "Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import XCTest
+
+@testable import MetovaTestKit
+
+// MARK: - TestViewController
+
+private class TestViewController: UIViewController {
+    
+    func testAction() {}
+    func someOtherAction() {}
+}
+
+// MARK: - UIBarButtonItemAssertionsTests
+
+class UIBarButtonItemTestingTests: MTKBaseTestCase {
+    
+    // MARK: Properties
+    
+    fileprivate let testVC = TestViewController()
+    
+    // MARK: Tests
+    
+    func testTargetActionSuccess() {
+        
+        let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: testVC, action: #selector(TestViewController.testAction))
+        MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVC)
+    }
+    
+    func testFailureDueToNoAction() {
+        
+        let failureExpectation = TestFailureExpectation(description: "failed - The bar button item's action is nil.", filePath: #file)
+
+        expectTestFailure(failureExpectation) {
+            
+            let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: testVC, action: nil)
+            MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVC)
+        }
+    }
+    
+    func testFailureDueToWrongAction() {
+        
+        let failureExpectation = TestFailureExpectation(description: "failed - Expected the bar button item to have action `testAction`. Instead found `someOtherAction`.", filePath: #file)
+        
+        expectTestFailure(failureExpectation) {
+            
+            let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: testVC, action: #selector(TestViewController.someOtherAction))
+            MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVC)
+        }
+    }
+    
+    func testFailureDueToNoTarget() {
+        
+        let failureExpectation = TestFailureExpectation(description: "failed - The bar button item's target is nil.", filePath: #file)
+        
+        expectTestFailure(failureExpectation) {
+            
+            let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: #selector(TestViewController.testAction))
+            MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVC)
+        }
+    }
+    
+    func testFailureDueToWrongTarget() {
+        
+        let otherTarget = TestViewController()
+        
+        let failureExpectation = TestFailureExpectation(description: "failed - Expected the bar button item to have target `\(testVC)`. Instead found `\(otherTarget)`.", filePath: #file)
+        
+        expectTestFailure(failureExpectation) {
+            
+            let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: otherTarget, action: #selector(TestViewController.testAction))
+            MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVC)
+        }
+    }
+    
+    func testFailureDueToTargetNotRespondingToAction() {
+        
+        let failureExpectation = TestFailureExpectation(description: "failed - The target does not respond to the action.", filePath: #file)
+        
+        expectTestFailure(failureExpectation) {
+            
+            let testVCThatDoesNotRespondToSelector = UIViewController()
+            let barButtonItem = UIBarButtonItem(title: "", style: .plain, target: testVCThatDoesNotRespondToSelector, action: #selector(TestViewController.testAction))
+            MTKAssertBarButtonItem(barButtonItem, sends: #selector(TestViewController.testAction), to: testVCThatDoesNotRespondToSelector)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Verify that a `UISegmentedControl` has the segment titles you are expecting.
 MTKAssertSegmentedControl(segmentedControl, hasSegmentTitles: ["Followers", "Following"])
 ```
  
+##### UIBarButtonItem
+ 
+Verify that a bar button item has the expected target/action pair and that the target actually responds to the selector that will be sent to it. 
+
+```swift
+MTKAssertBarButtonItem(testVC.editBarButtonItem, sends: #selector(MyViewController.didTapEditButton(_:)), to: testVC) 
+```
+ 
 #### Testing Constraints
 
 You can use Metova Test Kit to assert that you do not have broken autolayout constraints.


### PR DESCRIPTION
This is just like the MTK assertion for UIControl, but for UIBarButtonItem (which isn't a UIControl subclass).