### PR TITLE
Testing Dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Metova Test Kit CHANGELOG
 
+## Unpublished
+
+ - Added assertion for comparing `Date` objects only by specified components.
+
 ## 2.2.0
 
 - Added convenience method for testing UICollectionViewCells

--- a/MetovaTestKit.xcodeproj/project.pbxproj
+++ b/MetovaTestKit.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		4ADA98FE214AAA5400B91CF2 /* AsyncTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADA98FD214AAA5400B91CF2 /* AsyncTestingTests.swift */; };
 		4AE8F28521B099AC00417292 /* MTKTableViewTestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F28421B099AC00417292 /* MTKTableViewTestCell.swift */; };
 		4AE8F28A21B0A29800417292 /* MTKTableViewTestCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F28921B0A29800417292 /* MTKTableViewTestCellTests.swift */; };
+		4AEFB76721D403D8007FA095 /* MTKDateTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFB76621D403D8007FA095 /* MTKDateTesting.swift */; };
+		4AEFB76921D403E2007FA095 /* MTKDateTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFB76821D403E2007FA095 /* MTKDateTestingTests.swift */; };
 		6E0D0B461F1FEE3900600571 /* UIBarButtonItemTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0D0B451F1FEE3900600571 /* UIBarButtonItemTestingTests.swift */; };
 		6EC1A6B01EBCDDAF000DEFA6 /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC1A6AF1EBCDDAF000DEFA6 /* XCTestCase+AsyncTesting.swift */; };
 		8C5DBD5EA5193DF58D0EF97C /* Pods_MetovaTestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79631A34E94E032EB303D968 /* Pods_MetovaTestKit.framework */; };
@@ -104,6 +106,8 @@
 		4ADA98FD214AAA5400B91CF2 /* AsyncTestingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTestingTests.swift; sourceTree = "<group>"; };
 		4AE8F28421B099AC00417292 /* MTKTableViewTestCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTKTableViewTestCell.swift; sourceTree = "<group>"; };
 		4AE8F28921B0A29800417292 /* MTKTableViewTestCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTKTableViewTestCellTests.swift; sourceTree = "<group>"; };
+		4AEFB76621D403D8007FA095 /* MTKDateTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTKDateTesting.swift; sourceTree = "<group>"; };
+		4AEFB76821D403E2007FA095 /* MTKDateTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTKDateTestingTests.swift; sourceTree = "<group>"; };
 		6E0D0B451F1FEE3900600571 /* UIBarButtonItemTestingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemTestingTests.swift; sourceTree = "<group>"; };
 		6E1816671F2796EB0034E26E /* badge.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = badge.svg; sourceTree = "<group>"; };
 		6E1816691F2796EB0034E26E /* highlight.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = highlight.css; sourceTree = "<group>"; };
@@ -189,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				6EC1A6AE1EBCDD3F000DEFA6 /* AsynchronousTesting */,
+				4AEFB76421D403A5007FA095 /* DateTesting */,
 				4A3CFF241CDD60CE003EF6F0 /* ExceptionTesting */,
 				6E8D4B041EB7AD1B001284FD /* InternalUtilities */,
 				4A8AD4E71CDEA27E0085984D /* Testable */,
@@ -203,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				6EC1A6B11EBCE2C7000DEFA6 /* AsynchronousTestingTests */,
+				4AEFB76521D403B7007FA095 /* DateTestingTests */,
 				4ADA98FF214AAA7900B91CF2 /* ExceptionTestingTests */,
 				6E8D4B1C1EB8D644001284FD /* InternalUtilitiesTests */,
 				4AD3B579214AAAC20089FA1E /* TestableProtocolTests */,
@@ -322,6 +328,22 @@
 				4AE8F28921B0A29800417292 /* MTKTableViewTestCellTests.swift */,
 			);
 			path = CellTestingTests;
+			sourceTree = "<group>";
+		};
+		4AEFB76421D403A5007FA095 /* DateTesting */ = {
+			isa = PBXGroup;
+			children = (
+				4AEFB76621D403D8007FA095 /* MTKDateTesting.swift */,
+			);
+			path = DateTesting;
+			sourceTree = "<group>";
+		};
+		4AEFB76521D403B7007FA095 /* DateTestingTests */ = {
+			isa = PBXGroup;
+			children = (
+				4AEFB76821D403E2007FA095 /* MTKDateTestingTests.swift */,
+			);
+			path = DateTestingTests;
 			sourceTree = "<group>";
 		};
 		634135A92DFE71D915C1E3B7 /* Pods */ = {
@@ -678,6 +700,7 @@
 				6EC1A6B01EBCDDAF000DEFA6 /* XCTestCase+AsyncTesting.swift in Sources */,
 				4ADA98D7214AA65200B91CF2 /* UIAlertControllerAssertions.swift in Sources */,
 				4ADA98E1214AA67B00B91CF2 /* MTKConstraintTester.swift in Sources */,
+				4AEFB76721D403D8007FA095 /* MTKDateTesting.swift in Sources */,
 				4AE8F28521B099AC00417292 /* MTKTableViewTestCell.swift in Sources */,
 				4ADA98ED214AA69B00B91CF2 /* MTKTestable.swift in Sources */,
 				4AA895E421C4160D0088C2CB /* MTKCollectionViewTestCell.swift in Sources */,
@@ -700,6 +723,7 @@
 				4ADA98FE214AAA5400B91CF2 /* AsyncTestingTests.swift in Sources */,
 				4AE8F28A21B0A29800417292 /* MTKTableViewTestCellTests.swift in Sources */,
 				4ADA98F5214AAA1400B91CF2 /* FailureRecordingTests.swift in Sources */,
+				4AEFB76921D403E2007FA095 /* MTKDateTestingTests.swift in Sources */,
 				4ADA98FB214AAA2D00B91CF2 /* UISegmentedControlTestingTests.swift in Sources */,
 				4A3CFFCE1CDE1548003EF6F0 /* ExceptionTestingTests.swift in Sources */,
 				4ADA98F6214AAA1400B91CF2 /* QuotedStringTests.swift in Sources */,

--- a/MetovaTestKit/DateTesting/MTKDateTesting.swift
+++ b/MetovaTestKit/DateTesting/MTKDateTesting.swift
@@ -1,0 +1,28 @@
+//
+//  MTKDateTesting.swift
+//  MetovaTestKit
+//
+//  Created by Nick Griffith on 2019-12-26.
+//  Copyright © 2016 Metova. All rights reserved.
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  "Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//

--- a/MetovaTestKit/DateTesting/MTKDateTesting.swift
+++ b/MetovaTestKit/DateTesting/MTKDateTesting.swift
@@ -26,3 +26,52 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+import XCTest
+
+/// Compares two dates using only the provided components.  If any of the provided components are mismatched between the two dates, the test fails.  If no components are provided, the test always passes.
+///
+/// - Parameters:
+///   - lhs: A `Date` to compare.
+///   - rhs: A `Date` to compare.
+///   - components: Components to use to compare the two dates.
+///   - calendar: Calendar to use to pull components out of dates.  Defaults to `.current`.
+///   - message: An optional description of the failure.
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+public func MTKAssertEqualDates(_ lhs: Date, _ rhs: Date, comparing components: Calendar.Component..., calendar: Calendar = .current, message: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line) {
+    MTKAssertEqualDates(lhs, rhs, comparing: Set(components), calendar: calendar, message: message, file: file, line: line)
+}
+
+/// Compares two dates using only the provided components.  If any of the provided components are mismatched between the two dates, the test fails.  If no components are provided, the test always passes.
+///
+/// - Parameters:
+///   - lhs: A `Date` to compare.
+///   - rhs: A `Date` to compare.
+///   - components: Components to use to compare the two dates.
+///   - calendar: Calendar to use to pull components out of dates.  Defaults to `.current`.
+///   - message: An optional description of the failure.
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+public func MTKAssertEqualDates(_ lhs: Date, _ rhs: Date, comparing components: Set<Calendar.Component>, calendar: Calendar = .current, message: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line) {
+
+    var failureMessage = ""
+    
+    for component in components {
+        let lhsComponent = calendar.component(component, from: lhs)
+        let rhsComponent = calendar.component(component, from: rhs)
+
+        if lhsComponent != rhsComponent {
+            if let message = message() {
+                XCTFail("MTKAssertEqualDates failure - \(message)", file: file, line: line)
+                return
+            }
+            
+            failureMessage += "\n  \(component) value (\(lhsComponent)) of lhs is not equal to \(component) value (\(rhsComponent)) of rhs"
+        }
+    }
+    
+    if !failureMessage.isEmpty {
+        XCTFail(failureMessage, file: file, line: line)
+    }
+}

--- a/MetovaTestKitTests/DateTestingTests/MTKDateTestingTests.swift
+++ b/MetovaTestKitTests/DateTestingTests/MTKDateTestingTests.swift
@@ -26,3 +26,93 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+import XCTest
+
+@testable import MetovaTestKit
+
+class DateTestingTests: MTKBaseTestCase {
+    
+    func testIdenticalDatesPassAssertion() {
+        let components = DateComponents(calendar: nil, timeZone: nil, era: 0, year: 2018, month: 12, day: 25, hour: 6, minute: 57, second: 42, nanosecond: 8675309, weekday: 3, weekdayOrdinal: 4, quarter: 4, weekOfMonth: 4, weekOfYear: 52, yearForWeekOfYear: 2018)
+        guard let date1 = Calendar.current.date(from: components), let date2 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test dates!")
+            return
+        }
+        
+        MTKAssertEqualDates(date1, date2, comparing: .era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear)
+    }
+    
+    func testAlmostIdenticalDatesPassSpecificComponentAssertion() {
+        var components = DateComponents()
+        components.year = 2018
+        components.month = 12
+        components.day = 25
+        components.hour = 6
+        components.minute = 57
+        components.second = 42
+        components.nanosecond = 867309
+        guard let date1 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 1!")
+            return
+        }
+        
+        components.nanosecond = 0
+        guard let date2 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 2!")
+            return
+        }
+        
+        MTKAssertEqualDates(date1, date2, comparing: .year, .month, .day, .hour, .minute, .second)
+    }
+    
+    func testAlmostIdenticalDatesFailSpecificComponentAssertion() {
+        var components = DateComponents()
+        components.year = 2018
+        components.month = 12
+        components.day = 25
+        components.hour = 6
+        components.minute = 57
+        components.second = 42
+        guard let date1 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 1!")
+            return
+        }
+        
+        components.second = 43
+        guard let date2 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 2!")
+            return
+        }
+        
+        let description = "failed - \n  second value (42) of lhs is not equal to second value (43) of rhs"
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: #line+1)) {
+            MTKAssertEqualDates(date1, date2, comparing: .year, .month, .day, .hour, .minute, .second)
+        }
+    }
+    
+    func testDisplaysCustomMessageOnFailure() {
+        var components = DateComponents()
+        components.year = 2018
+        components.month = 12
+        components.day = 25
+        components.hour = 6
+        components.minute = 57
+        components.second = 42
+        guard let date1 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 1!")
+            return
+        }
+        
+        components.second = 43
+        guard let date2 = Calendar.current.date(from: components) else {
+            XCTFail("Failed to instantiate test date 2!")
+            return
+        }
+        
+        let description = "failed - MTKAssertEqualDates failure - Custom Message!"
+        expectTestFailure(TestFailureExpectation(description: description, lineNumber: #line+1)) {
+            MTKAssertEqualDates(date1, date2, comparing: .year, .month, .day, .hour, .minute, .second, .nanosecond, message: "Custom Message!")
+        }
+    }
+}

--- a/MetovaTestKitTests/DateTestingTests/MTKDateTestingTests.swift
+++ b/MetovaTestKitTests/DateTestingTests/MTKDateTestingTests.swift
@@ -1,0 +1,28 @@
+//
+//  MTKDateTestingTests.swift
+//  MetovaTestKit
+//
+//  Created by Nick Griffith on 2019-12-26.
+//  Copyright © 2016 Metova. All rights reserved.
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  "Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ MetovaTestKit is a collection of useful test helpers designed to ease the burden
         - [UICollectionViewCell](#uicollectionviewcell)
         - [UITableViewCell](#uitableviewcell)
         - [UISegmentedControl](#uisegmentedcontrol)
+    - [Testing Dates](#testing-dates)
     - [Testing Auto Layout Constraints](#testing-auto-layout-constraints)
     - [Testing Exceptions](#testing-exceptions)
     - [Asynchronous Testing](#asynchronous-testing)
@@ -162,6 +163,21 @@ Verify that a `UISegmentedControl` has the segment titles you are expecting.
  
 ```swift
 MTKAssertSegmentedControl(segmentedControl, hasSegmentTitles: ["Followers", "Following"])
+```
+ 
+## Testing Dates
+ 
+You can use MetovaTestKit to assert two dates are equal when only considering specified components.
+
+```swift
+MTKAssertEqualDates(date1, date2, comparing: .year, .month, .day)
+```
+
+This assertion accepts components as a variadic argument or as a `Set<Calendar.Component>`.
+
+```swift
+let components: Set<Calendar.Component> = [.year, .month, .day, .hour, .minute, .second]
+MTKAssertEqualDates(date1, date2, comparing: components)
 ```
  
 ## Testing Auto Layout Constraints

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ This assertion accepts components as a variadic argument or as a `Set<Calendar.C
 ```swift
 let components: Set<Calendar.Component> = [.year, .month, .day, .hour, .minute, .second]
 MTKAssertEqualDates(date1, date2, comparing: components)
+MTKAssertEqualDates(date3, date4, comparing: components)
+MTKAssertEqualDates(date5, date6, comparing: components)
 ```
  
 ## Testing Auto Layout Constraints


### PR DESCRIPTION
This pull request adds a convenient way of comparing two dates when non-exact matches are acceptable.

Out of the box, `Date` conforms to `Equatable`, so it can be used with `XCTAssertEqual`, however this comparison checks to make sure the dates are exactly equal.  Sometimes, we may not care about certain components of the date, be it milliseconds, second, or even the time part at all.  Sometimes we may just want to compare the year/month/day.

This PR adds a function that allows you to very easily do that without writing a lot of verbose boilerplate to make that comparison:

```
MTKAssertEqualDates(date1, date2, comparing: .year, .month, .day)
```